### PR TITLE
Added functionality to show status of app creation. 

### DIFF
--- a/src/commands/config.js
+++ b/src/commands/config.js
@@ -1,0 +1,14 @@
+const { Command } = require('@oclif/core');
+const Conf  = require('conf');
+const config = new Conf();
+const ui = require('../utils/ui');
+
+class ConfigCommand extends Command {
+  static description = 'Show config file location';
+
+  async run() {
+    ui.notify(`Location of your configuration file is:\n ${ui.ask(config.path)}\n`);
+  }
+}
+
+module.exports = ConfigCommand;

--- a/src/commands/deploy.js
+++ b/src/commands/deploy.js
@@ -4,7 +4,7 @@ const fs = require('fs');
 const getAppInfo = require('../prompts/getAppInfo');
 const Conf  = require('conf');
 const config = new Conf();
-const template = fs.readFileSync('./src/utils/test.yaml', 'utf8');
+const template = fs.readFileSync('./src/utils/bastion.yaml', 'utf8');
 const errorHandler = require('../utils/errorHandler');
 const ui = require('../utils/ui');
 
@@ -47,7 +47,6 @@ class DeployCommand extends Command {
           "To see your if your admin dashboard is ready use 'bastion show' \n";
         ui.notify(successMessage);
         storeInfraName({ name, region });
-        console.log(`Location of your configuration file: ${config.path}`);
       }
     } catch(err) {
       errorHandler.handleDeploy(err);

--- a/src/commands/deploy.js
+++ b/src/commands/deploy.js
@@ -1,5 +1,5 @@
 const { Command } = require('@oclif/core');
-const { CloudFormationClient, CreateStackCommand, DescribeStacksCommand } = require('@aws-sdk/client-cloudformation');
+const { CloudFormationClient, CreateStackCommand } = require('@aws-sdk/client-cloudformation');
 const fs = require('fs');
 const getAppInfo = require('../prompts/getAppInfo');
 const Conf  = require('conf');
@@ -47,6 +47,7 @@ class DeployCommand extends Command {
           "To see your if your admin dashboard is ready use 'bastion show' \n";
         ui.notify(successMessage);
         storeInfraName({ name, region });
+        console.log(`Location of your configuration file: ${config.path}`);
       }
     } catch(err) {
       errorHandler.handleDeploy(err);

--- a/src/commands/show.js
+++ b/src/commands/show.js
@@ -2,6 +2,7 @@ const { Command } = require('@oclif/core');
 const { CloudFormationClient, DescribeStacksCommand } = require('@aws-sdk/client-cloudformation');
 const Conf  = require('conf');
 const config = new Conf();
+const ui = require('../utils/ui');
 const errorHandler = require('../utils/errorHandler');
 const getAppName = require('../prompts/getAppName');
 
@@ -22,20 +23,24 @@ class Show extends Command {
 
   async run() {
     const appName = await getAppName();
+    if (!appName) { return };
+
     const region = getRegion(appName);
 
     const client = new CloudFormationClient({ region: region });
     const command = new DescribeStacksCommand({ StackName: appName });
+    let spinner;
 
     try {
+      spinner = ui.runSpinner(ui.ask('Retrieving your stack status...'));
       const response = await client.send(command);
       const status = response.Stacks[0].StackStatus;
 
       if (status === 'CREATE_COMPLETE') {
-        console.log('Your app is ready!');
-        console.log(`Your DNS name is: ${getDNS(response)}`);
+        ui.notify('Your app is ready!');
+        ui.notify(`Your DNS name is: ${getDNS(response)}`);
       } else {
-        console.log(`Not ready yet. Your AWS stack status: ${status}`);
+        spinner.fail(console.log(ui.ask(`Not ready yet. Your AWS stack status: ${status}`)));
       }
     } catch(err) {
       errorHandler.handleShow(err);

--- a/src/commands/show.js
+++ b/src/commands/show.js
@@ -1,0 +1,46 @@
+const { Command } = require('@oclif/core');
+const { CloudFormationClient, DescribeStacksCommand } = require('@aws-sdk/client-cloudformation');
+const Conf  = require('conf');
+const config = new Conf();
+const errorHandler = require('../utils/errorHandler');
+const getAppName = require('../prompts/getAppName');
+
+const getRegion = (name) => {
+  return JSON.parse(config.get('INFRA_NAMES'))
+    .filter(infra => infra.name === name)[0]
+    .region;
+};
+
+const getDNS = (response) => {
+  return response.Stacks[0].Outputs
+    .filter(outputObj => outputObj.OutputKey === 'ALBDomain')[0]
+    .OutputValue;
+}
+
+class Show extends Command {
+  static description = 'Show the status of your Bastion application';
+
+  async run() {
+    const appName = await getAppName();
+    const region = getRegion(appName);
+
+    const client = new CloudFormationClient({ region: region });
+    const command = new DescribeStacksCommand({ StackName: appName });
+
+    try {
+      const response = await client.send(command);
+      const status = response.Stacks[0].StackStatus;
+
+      if (status === 'CREATE_COMPLETE') {
+        console.log('Your app is ready!');
+        console.log(`Your DNS name is: ${getDNS(response)}`);
+      } else {
+        console.log(`Not ready yet. Your AWS stack status: ${status}`);
+      }
+    } catch(err) {
+      errorHandler.handleShow(err);
+    }
+  }
+}
+
+module.exports = Show;

--- a/src/prompts/deletePrompt.js
+++ b/src/prompts/deletePrompt.js
@@ -11,7 +11,7 @@ const getCurrentInfraNames = () => {
 const deletePrompt = async () => {
   let currentInfras = getCurrentInfraNames();
   if (currentInfras.length === 0) {
-    const message = "It seems like you dont have any Bastion infrastructure deployed"
+    const message = "It seems like you dont have any Bastion infrastructure deployed";
     ui.warn(message);
     return;
   }

--- a/src/prompts/getAppInfo.js
+++ b/src/prompts/getAppInfo.js
@@ -1,8 +1,9 @@
 const inquirer = require('inquirer');
 const ui = require('../utils/ui');
+const chalk = require('chalk');
 
 const infraNameValidator = async (input) => {
-  return /[A-Z]/.test(input)
+  return /[A-Za-z]/.test(input);
 }
 
 const getAppInfo = async () => {

--- a/src/prompts/getAppName.js
+++ b/src/prompts/getAppName.js
@@ -1,0 +1,25 @@
+const inquirer = require('inquirer');
+const Conf  = require('conf');
+const config = new Conf();
+
+const infraArr = JSON.parse(config.get('INFRA_NAMES') || '[]');
+
+const getAppName = async () => {
+  if (infraArr.length === 0) {
+    console.log("It seems like you don't have any bastion infrastructure deployed");
+    return;
+  }
+
+  let response = await inquirer.prompt([
+    {
+      name: 'appName',
+      message: 'Select the app you want to check the status of:',
+      type: 'list',
+      choices: infraArr,
+    }
+  ]);
+
+  return response.appName;
+};
+
+module.exports = getAppName; 

--- a/src/prompts/getAppName.js
+++ b/src/prompts/getAppName.js
@@ -1,19 +1,20 @@
 const inquirer = require('inquirer');
 const Conf  = require('conf');
+const ui = require('../utils/ui');
 const config = new Conf();
 
 const infraArr = JSON.parse(config.get('INFRA_NAMES') || '[]');
 
 const getAppName = async () => {
   if (infraArr.length === 0) {
-    console.log("It seems like you don't have any bastion infrastructure deployed");
+    ui.warn("It seems like you don't have any bastion infrastructure deployed");
     return;
   }
 
   let response = await inquirer.prompt([
     {
       name: 'appName',
-      message: 'Select the app you want to check the status of:',
+      message: ui.ask('Select the app you want to check the status of:'),
       type: 'list',
       choices: infraArr,
     }

--- a/src/utils/bastion.yaml
+++ b/src/utils/bastion.yaml
@@ -491,3 +491,8 @@ Resources:
           FromPort: 80
           ToPort: 80
           CidrIp: 0.0.0.0/0
+
+Outputs:
+  ALBDomain:
+    Description: Application Load Balancer Domain Name
+    Value: !GetAtt ALB.DNSName

--- a/src/utils/bastion.yaml
+++ b/src/utils/bastion.yaml
@@ -9,6 +9,9 @@ Parameters:
   AdminAppImage:
     Type: String
     Default: 'public.ecr.aws/y7d9d7k6/public_dummy:0.1.0'
+  CCFBucketName:
+    Type: String
+    Default: ccf-bucket
 Resources:
   BastionVPC:
     Type: 'AWS::EC2::VPC'
@@ -193,7 +196,7 @@ Resources:
               - Effect: Allow
                 Action: 's3:*'
                 Resource:
-                  - 'arn:aws:s3:::ccf-bucket'
+                  - !GetAtt CCFBucket.Arn
         - PolicyName: CCFLambdaPolicy
           PolicyDocument:
             Version: 2012-10-17
@@ -201,6 +204,8 @@ Resources:
               - Effect: Allow
                 Action: 'lambda:*'
                 Resource: '*'
+      DependsOn:
+        - CCFBucket
   AdminAppTaskDefinition:
     Type: 'AWS::ECS::TaskDefinition'
     Properties:
@@ -377,7 +382,7 @@ Resources:
     Type: 'AWS::S3::Bucket'
     Description: S3 Bucket for Cloud Code Function zip files
     Properties:
-      BucketName: ccf-bucket
+      BucketName: !Ref CCFBucketName
       VersioningConfiguration:
         Status: Suspended
       AccessControl: Private

--- a/src/utils/errorHandler.js
+++ b/src/utils/errorHandler.js
@@ -10,4 +10,8 @@ const handleDestroy = (err) => {
   ui.warn(err.Error, true);
 }
 
-module.exports = { handleDeploy, handleDestroy };
+const handleShow = (err) => {
+  console.log(err.Error);
+}
+
+module.exports = { handleDeploy, handleDestroy, handleShow };

--- a/src/utils/errorHandler.js
+++ b/src/utils/errorHandler.js
@@ -11,7 +11,7 @@ const handleDestroy = (err) => {
 }
 
 const handleShow = (err) => {
-  console.log(err.Error);
+  console.log(ui.ask(err.Error));
 }
 
 module.exports = { handleDeploy, handleDestroy, handleShow };

--- a/src/utils/test.yaml
+++ b/src/utils/test.yaml
@@ -11,3 +11,8 @@ Resources:
     Type: AWS::ECS::Cluster
     Properties:
       ClusterName: !Ref InfraName
+      Tags:
+        - Key: stack
+          Value: Bastion
+        - Key: region
+          Value: !Ref Region


### PR DESCRIPTION
DNS name is shown upon successful creation of infrastructure. It is pulled in from the CF template output. Right now I'm just logging it. Also added a message showing the path to the config file on creation.

Show gives you options of app names in your config. Upon choosing one, if it isn't done you get a "not ready yet" message. If it is done, it tells you the DNS name from the ALB.

Added to the error handler. It's the same as `handleDestroy` right now, but it could change in the future.