### PR TITLE
Add Roles and SGs of App and DB Servers to initial deployment file

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ If you use `bastion destroy` before `bastion deploy` has fully provisioned your 
 
 <br>
 
-## `bastion **help [COMMAND]**`
+## `bastion help [COMMAND]`
 
 Displays help for Bastion CLI commands
 
@@ -105,4 +105,3 @@ Shows the location of your local configuration file. This file contains the name
 ## `bastion show`
 
 Displays the status of a stack you have created with `bastion deploy`. It tells you if your infrastructure is ready and if so, gives you a DNS name. You will be prompted for the name of the stack you would like to check the status of.
-

--- a/src/utils/bastion.yaml
+++ b/src/utils/bastion.yaml
@@ -465,6 +465,33 @@ Resources:
               - Effect: Allow
                 Action: 'lambda:*'
                 Resource: '*'
+  RoleDBServer:
+    Type: 'AWS::IAM::Role'
+    Properties:
+      Tags:
+        - Key: stack
+          Value: Bastion
+        - Key: name
+          Value: !Ref InfraName
+      RoleName: RoleDBServer
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Sid: ''
+            Effect: Allow
+            Principal:
+              Service:
+                - ecs-tasks.amazonaws.com
+            Action:
+              - 'sts:AssumeRole'
+      Policies:
+        - PolicyName: DBServerRolePolicy
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Effect: Allow
+                Action: '*'
+                Resource: '*'
   SGCCF:
     Type: 'AWS::EC2::SecurityGroup'
     Properties:
@@ -494,7 +521,48 @@ Resources:
           FromPort: 80
           ToPort: 80
           CidrIp: 0.0.0.0/0
-
+  SGAppServer:
+    Type: 'AWS::EC2::SecurityGroup'
+    Properties:
+      GroupName: SGAppServer
+      GroupDescription: Security Group for BaaS instance App Server
+      VpcId: !Ref BastionVPC
+      SecurityGroupIngress:
+        - IpProtocol: tcp
+          FromPort: 0
+          ToPort: 30000
+          CidrIp: 0.0.0.0/0
+      SecurityGroupEgress:
+        - IpProtocol: tcp
+          FromPort: 0
+          ToPort: 30000
+          CidrIp: 0.0.0.0/0
+      Tags:
+        - Key: stack
+          Value: bastion
+        - Key: name
+          Value: !Ref InfraName
+  SGDBServer:
+    Type: 'AWS::EC2::SecurityGroup'
+    Properties:
+      GroupName: SGDBServer
+      GroupDescription: Security Group for BaaS instance App Server
+      VpcId: !Ref BastionVPC
+      SecurityGroupIngress:
+        - IpProtocol: tcp
+          FromPort: 0
+          ToPort: 30000
+          CidrIp: 0.0.0.0/0
+      SecurityGroupEgress:
+        - IpProtocol: tcp
+          FromPort: 0
+          ToPort: 30000
+          CidrIp: 0.0.0.0/0
+      Tags:
+        - Key: stack
+          Value: bastion
+        - Key: name
+          Value: !Ref InfraName
 Outputs:
   ALBDomain:
     Description: Application Load Balancer Domain Name

--- a/src/utils/bastion.yaml
+++ b/src/utils/bastion.yaml
@@ -563,6 +563,26 @@ Resources:
           Value: bastion
         - Key: name
           Value: !Ref InfraName
+  InstanceEFS:
+    Type: 'AWS::EFS::FileSystem'
+    Properties:
+      Encrypted: true
+      PerformanceMode: generalPurpose
+  EFSSecurityGroup:
+    Type: 'AWS::EC2::SecurityGroup'
+    Properties:
+      SecurityGroupIngress:
+        - IpProtocol: tcp
+          FromPort: 0
+          ToPort: 30000
+          CidrIp: 0.0.0.0/0
+      SecurityGroupEgress:
+        - IpProtocol: tcp
+          FromPort: 0
+          ToPort: 30000
+          CidrIp: 0.0.0.0/0
+      VpcId: !Ref BastionVPC
+      GroupDescription: Test
 Outputs:
   ALBDomain:
     Description: Application Load Balancer Domain Name


### PR DESCRIPTION
Security groups and roles are still quite comprehensive as agreed. Im adding todos to our Kanban so that we can take a look at this later